### PR TITLE
fix(build): do not whitelist object literal spread in eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,9 +13,6 @@ module.exports = {
         '__filename': false
     },
     'parserOptions': {
-        'ecmaFeatures': {
-            'experimentalObjectRestSpread': true
-        },
         'sourceType': 'module'
     },
     'rules': {


### PR DESCRIPTION
It is not a standard feature right now and cannot be used
in stock node.