### PR TITLE
feat(google-auth): expose methods to enable opening google auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,27 +13,35 @@ The Google API utility exposes methods for performing Google client-side authent
 
 **Enable the Google API integration:**
 
-In the **main** electron process:
+To set up the Google API integration, in the **main** electron process, execute `setupGoogleApiMain`. This will set up listeners on the main processes to be aware of requests to open a Google popup.
 ```Javascript
 const { setupGoogleApiMain } = require("jitsi-meet-electron-utils");
 const options = {
     browserWindowOptions: {
-        webPreferences: {
-            nodeIntegration: false
-        }
+        ...
     }
 };
 setupGoogleApiMain(options);
 ```
 
-In the **render** electron process of the window where Jitsi Meet is displayed:
+The function `setupGoogleApiMain` takes in an options objects the supports the following:
+- `browserWindowOptions`: The BrowserWindow options object to pass into the Google authentication popup. These are the same options as supported by the [BrowserWindow class](https://github.com/electron/electron/blob/master/docs/api/browser-window.md#class-browserwindow). By default the following options will be used:
+    ```
+    {
+        webPreferences: {
+            nodeIntegration: false
+        }
+    }
+    ```
+
+To finish setting up the Google API integration, in the **render** electron process of the window where Jitsi Meet is displayed, execute `setupGoogleApiRender` to expose globals to Jitsi-Meet to interact indirectly with the main processes.
 ```Javascript
 const { setupGoogleApiRender } = require("jitsi-meet-electron-utils");
 const api = new JitsiMeetExternalAPI(...);
 setupGoogleApiRender(api);
 ```
 
-To clean up Google API integration, in the **main** electron process:
+To clean up various listeners attached by the Google API integration, in the **main** electron process:
 ```
 teardownGoogleApi();
 ```

--- a/README.md
+++ b/README.md
@@ -7,6 +7,35 @@ jitsi-meet-electron-utils contains native code for some utilities. You'll need [
 NOTE: For Linux install libxtst-dev and libpng++-dev (`sudo apt-get install libxtst-dev libpng++-dev`). This dependancies are related to RobotJS which is a dependency of jitsi-meet-electron-utils. You can see the build instructions for RobotJS [here](https://github.com/jitsi/robotjs/tree/jitsi#building)
 
 ## Usage
+#### Google API
+The Google API utility exposes methods for performing Google client-side authentication by opening a oauth popup window and passing back the redirect URL with the Google access token.
+
+**Enable the Google API integration:**
+
+In the **main** electron process:
+```Javascript
+const { setupGoogleApiMain } = require("jitsi-meet-electron-utils");
+const options = {
+    browserWindowOptions: {
+        webPreferences: {
+            nodeIntegration: false
+        }
+    }
+};
+setupGoogleApiMain(options);
+```
+
+In the **render** electron process of the window where Jitsi Meet is displayed:
+```Javascript
+const { setupGoogleApiRender } = require("jitsi-meet-electron-utils");
+const api = new JitsiMeetExternalAPI(...);
+setupGoogleApiRender(api);
+```
+
+To clean up Google API integration:
+```
+teardownGoogleApi();
+```
 #### Remote Control
 
 **Requirements**:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ jitsi-meet-electron-utils contains native code for some utilities. You'll need [
 NOTE: For Linux install libxtst-dev and libpng++-dev (`sudo apt-get install libxtst-dev libpng++-dev`). This dependancies are related to RobotJS which is a dependency of jitsi-meet-electron-utils. You can see the build instructions for RobotJS [here](https://github.com/jitsi/robotjs/tree/jitsi#building)
 
 ## Usage
+
 #### Google API
 The Google API utility exposes methods for performing Google client-side authentication by opening a oauth popup window and passing back the redirect URL with the Google access token.
 
@@ -32,7 +33,7 @@ const api = new JitsiMeetExternalAPI(...);
 setupGoogleApiRender(api);
 ```
 
-To clean up Google API integration:
+To clean up Google API integration, in the **main** electron process:
 ```
 teardownGoogleApi();
 ```

--- a/googleapi/constants.js
+++ b/googleapi/constants.js
@@ -1,4 +1,12 @@
 module.exports = {
+    /**
+     * The event for when the Google authentication has completed, either
+     * successfully or unsuccessfully.
+     */
     AUTH_FINISHED: 'jitsi-google-auth-finish',
+
+    /**
+     * The event for requesting the Google authentication popup to display.
+     */
     AUTH_REQUESTED: 'jitsi-google-auth-open'
 };

--- a/googleapi/constants.js
+++ b/googleapi/constants.js
@@ -1,0 +1,4 @@
+module.exports = {
+    AUTH_FINISHED: 'jitsi-google-auth-finish',
+    AUTH_REQUESTED: 'jitsi-google-auth-open'
+};

--- a/googleapi/index.js
+++ b/googleapi/index.js
@@ -1,0 +1,9 @@
+const { setupGoogleApiMain } = require('./main');
+const { setupGoogleApiRender } = require('./render');
+const teardownGoogleApi = require('./teardown');
+
+module.exports = {
+    setupGoogleApiMain,
+    setupGoogleApiRender,
+    teardownGoogleApi
+};

--- a/googleapi/main.js
+++ b/googleapi/main.js
@@ -1,0 +1,112 @@
+const electron = require('electron');
+const { BrowserWindow, ipcMain } = electron;
+
+const constants = require('./constants');
+
+/**
+ * Options to pass into new {@code BrowserWindow} instances if none are
+ * specified.
+ *
+ * @private
+ * @type {Object}
+ */
+const defaultBrowserWindowOptions = {
+    webPreferences: {
+        nodeIntegration: false
+    }
+};
+
+/**
+ * The configured {@code BrowserWindow} options to pass in to new BrowserWindow
+ * instances. This value can be overridden in {@code setupGoogleApiMain}.
+ *
+ * @private
+ * @type {Object}
+ */
+let browserWindowOptions = defaultBrowserWindowOptions;
+
+/**
+ * A reference to the opened Google authentication window. Kept so the window
+ * can be closed on call to {@code teardownGoogleApiMain}.
+ *
+ * @private
+ * @type {BrowserWindow|null}
+ */
+let googlePopup = null;
+
+/**
+ * Opens a new {@code BrowserWindow} instance for Google authentication and
+ * listens for redirects to a specified redirect URI.
+ *
+ * @param {Object} authRequestEvent - The event object passed from Electron.
+ * @param {Object} options - The additional arguments from the event.
+ * @param {string} options.authUrl - The URL to display for authentication.
+ * @param {string} options.redirectUri - The URL that is expected to be
+ * displayed after successful authentication.
+ * @private
+ * @returns {void}
+ */
+function onAuthRequested(authRequestEvent, options) {
+    if (googlePopup) {
+        googlePopup.focus();
+        return;
+    }
+
+    googlePopup = new BrowserWindow(browserWindowOptions);
+
+    googlePopup.loadURL(options.authUrl);
+
+    googlePopup.on('closed', () => {
+        // Fire this again in case the user closed the modal without finishing
+        // authentication.
+        authRequestEvent.sender.send(constants.AUTH_FINISHED);
+
+        googlePopup = null;
+    });
+
+    googlePopup.webContents.on('did-navigate', (navEvent, url) => {
+        if (url.indexOf(options.redirectUri) === 0) {
+            authRequestEvent.sender.send(constants.AUTH_FINISHED, url);
+            googlePopup.close();
+        }
+    });
+}
+
+/**
+ * Sets listeners on the main Electron process to handle requests to open a
+ * {@code BrowserWindow} instance for Google authentication.
+ *
+ * @param {Object} options - Additional configuration for setting up the
+ * listeners.
+ * @param {Object} browserWindowOptions - The options to pass into the
+ * constructor for {@code BrowserWindow}.
+ * @returns {void}
+ */
+function setupGoogleApiMain(options = {}) {
+    teardownGoogleApiMain();
+
+    browserWindowOptions
+        = options.browserWindowOptions || defaultBrowserWindowOptions;
+
+    ipcMain.on(constants.AUTH_REQUESTED, onAuthRequested);
+}
+
+/**
+ * Removes listeners on the main Electron process for opening new windows for
+ * getting a Google access token.
+ *
+ * @returns {void}
+ */
+function teardownGoogleApiMain() {
+    ipcMain.removeAllListeners(constants.AUTH_REQUESTED);
+    browserWindowOptions = defaultBrowserWindowOptions;
+
+    if (googlePopup) {
+        googlePopup.close();
+    }
+}
+
+module.exports = {
+    setupGoogleApiMain,
+    teardownGoogleApiMain
+};

--- a/googleapi/main.js
+++ b/googleapi/main.js
@@ -23,7 +23,7 @@ const defaultBrowserWindowOptions = {
  * @private
  * @type {Object}
  */
-let browserWindowOptions = defaultBrowserWindowOptions;
+let browserWindowOptions = undefined;
 
 /**
  * A reference to the opened Google authentication window. Kept so the window
@@ -99,7 +99,7 @@ function setupGoogleApiMain(options = {}) {
  */
 function teardownGoogleApiMain() {
     ipcMain.removeAllListeners(constants.AUTH_REQUESTED);
-    browserWindowOptions = defaultBrowserWindowOptions;
+    browserWindowOptions = undefined;
 
     if (googlePopup) {
         googlePopup.close();

--- a/googleapi/render.js
+++ b/googleapi/render.js
@@ -1,0 +1,100 @@
+const electron = require('electron');
+const ipcRenderer = electron.ipcRenderer;
+
+const constants = require('./constants');
+
+/**
+ * A private reference to the iframe with the Jitsi Meet meeting.
+ *
+ * @private
+ * @type {InlineFrameElement}
+ */
+let iframe = null;
+
+/**
+ * A helper object for performing interactions with the Google API that may not
+ * be possible otherwise in Electron with the Google JS Client.
+ *
+ * @type {Object}
+ */
+const googleApi = {
+    /**
+     * Sends a request to the main process to open the passed in Google auth
+     * URL and sets a listener for the main process's response.
+     *
+     * @param {Object} options - An object describing how to handle the auth
+     * flow.
+     * @param {string} options.authUrl - The Google oauth URL to visit to ask
+     * for access to the user's account.
+     * @param {string} options.rediredirectUrl - The URL that is expected to be
+     * visited after the Google oauth process is complete.
+     * @returns {Promise}
+     */
+    requestToken(options) {
+        return new Promise(resolve => {
+            ipcRenderer.once(constants.AUTH_FINISHED, (event, url) => {
+                resolve(url);
+            });
+
+            ipcRenderer.send(constants.AUTH_REQUESTED, options);
+        });
+    }
+};
+
+/**
+ * Sets {@code googleApi} on a global variable for Jitsi Meet to access.
+ *
+ * @private
+ * @returns {void}
+ */
+function setGlobalGoogleApiVariable() {
+    if (!iframe) {
+        return;
+    }
+
+    iframe.contentWindow.JitsiMeetElectron
+        = iframe.contentWindow.JitsiMeetElectron || {};
+
+    iframe.contentWindow.JitsiMeetElectron.googleApi = googleApi;
+}
+
+/**
+ * Sets a global variable on the Jitsi Meet iFrame to expose Google API
+ * functionality that needs to be executed in Electron's main context.
+ *
+ * @param {JitsiIFrameApi} api - The Jitsi Meet iframe api object.
+ * @returns {void}
+ */
+function setupGoogleApiRender(api) {
+    teardownGoogleApiRender();
+
+    iframe = api.getIFrame();
+
+    iframe && iframe.addEventListener('load', setGlobalGoogleApiVariable);
+}
+
+/**
+ * Removes listeners that may have been set for interacting with the Google API.
+ *
+ * @returns {void}
+ */
+function teardownGoogleApiRender() {
+    if (iframe) {
+        iframe.removeEventListener('load', setGlobalGoogleApiVariable);
+
+        if (iframe.contentWindow && iframe.contentWindow.JitsiMeetElectron) {
+            delete iframe.contentWindow.JitsiMeetElectron.googleApi;
+        }
+
+        iframe = null;
+    }
+
+    if (ipcRenderer) {
+        ipcRenderer.removeAllListeners(constants.AUTH_FINISHED);
+    }
+}
+
+module.exports = {
+    setupGoogleApiRender,
+    teardownGoogleApiRender
+};

--- a/googleapi/teardown.js
+++ b/googleapi/teardown.js
@@ -1,0 +1,13 @@
+const { teardownGoogleApiMain } = require('./main');
+const { teardownGoogleApiRender } = require('./render');
+
+/**
+ * Executes teardown that undoes setup that may have been performed by the
+ * googleapi module.
+ *
+ * @returns {void}
+ */
+module.exports = function teardownGoogleApi() {
+    teardownGoogleApiMain();
+    teardownGoogleApiRender();
+};

--- a/index.js
+++ b/index.js
@@ -1,5 +1,11 @@
+const {
+    setupGoogleApiMain,
+    setupGoogleApiRender,
+    teardownGoogleApi
+} = require('./googleapi');
 const RemoteControl = require('./remotecontrol');
 const setupScreenSharingForWindow = require('./screensharing');
+const teardown = require('./teardown');
 const {
     setupAlwaysOnTopRender,
     setupAlwaysOnTopMain
@@ -9,8 +15,12 @@ const { getWiFiStats, setupWiFiStats } = require('./wifistats');
 module.exports = {
     getWiFiStats,
     RemoteControl,
+    setupGoogleApiMain,
+    setupGoogleApiRender,
     setupScreenSharingForWindow,
     setupAlwaysOnTopRender,
     setupAlwaysOnTopMain,
-    setupWiFiStats
+    setupWiFiStats,
+    teardown,
+    teardownGoogleApi
 };

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ const {
 } = require('./googleapi');
 const RemoteControl = require('./remotecontrol');
 const setupScreenSharingForWindow = require('./screensharing');
-const teardown = require('./teardown');
 const {
     setupAlwaysOnTopRender,
     setupAlwaysOnTopMain
@@ -21,6 +20,5 @@ module.exports = {
     setupAlwaysOnTopRender,
     setupAlwaysOnTopMain,
     setupWiFiStats,
-    teardown,
     teardownGoogleApi
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jitsi-meet-electron-utils",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Utilities for jitsi-meet-electron project",
   "main": "index.js",
   "scripts": {

--- a/screensharing/index.js
+++ b/screensharing/index.js
@@ -3,23 +3,25 @@ module.exports = function setupScreenSharingForWindow(iframe) {
     // make sure that even after reload/redirect the screensharing will be
     // available
     iframe.addEventListener('load', () => {
-        iframe.contentWindow.JitsiMeetElectron = {
-            /**
-             * Get sources available for screensharing. The callback is invoked
-             * with an array of DesktopCapturerSources.
-             *
-             * @param {Function} callback - The success callback.
-             * @param {Function} errorCallback - The callback for errors.
-             * @param {Object} options - Configuration for getting sources.
-             * @param {Array} options.types - Specify the desktop source types
-             * to get, with valid sources being "window" and "screen".
-             * @param {Object} options.thumbnailSize - Specify how big the
-             * preview images for the sources should be. The valid keys are
-             * height and width, e.g. { height: number, width: number}. By
-             * default electron will return images with height and width of
-             * 150px.
-             */
-            obtainDesktopStreams(callback, errorCallback, options = {}) {
+        iframe.contentWindow.JitsiMeetElectron
+            = iframe.contentWindow.JitsiMeetElectron || {};
+
+        /**
+         * Get sources available for screensharing. The callback is invoked with
+         * an array of DesktopCapturerSources.
+         *
+         * @param {Function} callback - The success callback.
+         * @param {Function} errorCallback - The callback for errors.
+         * @param {Object} options - Configuration for getting sources.
+         * @param {Array} options.types - Specify the desktop source types to
+         * get, with valid sources being "window" and "screen".
+         * @param {Object} options.thumbnailSize - Specify how big the preview
+         * images for the sources should be. The valid keys are height and
+         * width, e.g. { height: number, width: number}. By default electron
+         * will return images with height and width of 150px.
+         */
+        iframe.contentWindow.JitsiMeetElectron.obtainDesktopStreams
+            = function(callback, errorCallback, options = {}) {
                 electron.desktopCapturer.getSources(options,
                     (error, sources) => {
                         if (error) {
@@ -29,7 +31,6 @@ module.exports = function setupScreenSharingForWindow(iframe) {
 
                         callback(sources);
                     });
-            }
-        };
+            };
     });
 };

--- a/teardown/index.js
+++ b/teardown/index.js
@@ -1,0 +1,5 @@
+const { teardownGoogleApi } = require('../googleapi');
+
+module.exports = function teardown() {
+    teardownGoogleApi();
+};

--- a/teardown/index.js
+++ b/teardown/index.js
@@ -1,5 +1,0 @@
-const { teardownGoogleApi } = require('../googleapi');
-
-module.exports = function teardown() {
-    teardownGoogleApi();
-};


### PR DESCRIPTION
- Expose a setup method to allow the jitsi iframe to open a new
  window, which listens for a specific redirect URL and passes
  back the full redirect URL.
- Expose a setup method that puts a global on the jitsi iframe
  to exercise opening the new window.
- Expose teardown methods to ensure listeners get cleaned up.

Related jitsi-meet changes: https://github.com/jitsi/jitsi-meet/pull/3106
Related jitsi-meet-electron changes: https://github.com/jitsi/jitsi-meet-electron/pull/39