### PR TITLE
Fix error with mouse moving in Windows with multiple displays

### DIFF
--- a/node_addons/sourceId2Coordinates/index.js
+++ b/node_addons/sourceId2Coordinates/index.js
@@ -1,6 +1,4 @@
-const sourceId2Coordinates
-    = require("../../build/Release/sourceId2Coordinates.node")
-        .sourceId2Coordinates;
+const {sourceId2Coordinates, moveMouse} = require("../../build/Release/sourceId2Coordinates.node");
 
 /**
  * Returns the coordinates of a desktop using the passed desktop sharing source
@@ -11,7 +9,7 @@ const sourceId2Coordinates
  * top left corner of the desktop. Currently works only for windows. Returns
  * undefined for Mac OS, Linux.
  */
-module.exports = function(sourceId) {
+module.exports.sourceId2Coordinates = function(sourceId) {
     if(typeof sourceId !== "string" || sourceId === '') {
         return undefined;
     }
@@ -19,8 +17,11 @@ module.exports = function(sourceId) {
     // we need the "desktop_id" only to get the coordinates.
     const idArr = sourceId.split(":");
     const id = Number(idArr.length > 1 ? idArr[0] : sourceId);
+
     if(!isNaN(id)) {
         return sourceId2Coordinates(id);
     }
     return undefined;
 };
+
+module.exports.moveMouse = moveMouse;

--- a/node_addons/sourceId2Coordinates/src/index.cc
+++ b/node_addons/sourceId2Coordinates/src/index.cc
@@ -11,7 +11,9 @@ NAN_METHOD(sourceId2Coordinates)
 	const int sourceID = info[0]->Int32Value();
 	Local<Object> obj = Nan::New<Object>();
 	Point coordinates;
-	if(!sourceId2Coordinates(sourceID, &coordinates))
+	int displayWidth;
+	int displayHeight;
+	if(!sourceId2Coordinates(sourceID, &coordinates, displayWidth, displayHeight))
 	{ // return undefined if sourceId2Coordinates function fail.
 		info.GetReturnValue().Set(Nan::Undefined());
 	}
@@ -19,8 +21,27 @@ NAN_METHOD(sourceId2Coordinates)
 	{ // return the coordinates if sourceId2Coordinates function succeed.
 		Nan::Set(obj, Nan::New("x").ToLocalChecked(), Nan::New(coordinates.x));
 		Nan::Set(obj, Nan::New("y").ToLocalChecked(), Nan::New(coordinates.y));
+
+		Nan::Set(obj, Nan::New("width").ToLocalChecked(), Nan::New(displayWidth));
+		Nan::Set(obj, Nan::New("height").ToLocalChecked(), Nan::New(displayHeight));
+		
+		Nan::Set(obj, Nan::New("vscreenWidth").ToLocalChecked(), Nan::New(vscreen_width));
+		Nan::Set(obj, Nan::New("vscreenHeight").ToLocalChecked(), Nan::New(vscreen_height));
+		Nan::Set(obj, Nan::New("vscreenMinX").ToLocalChecked(), Nan::New(vscreen_min_x));
+		Nan::Set(obj, Nan::New("vscreenMinY").ToLocalChecked(), Nan::New(vscreen_min_y));
+
 		info.GetReturnValue().Set(obj);
 	}
+}
+
+NAN_METHOD(moveMouse)
+{
+	const int x = info[0]->Int32Value();
+	const int y = info[1]->Int32Value();
+	int result = moveMouse(x,y);
+	Local<Number> n = Nan::New<Number>(result);
+
+	info.GetReturnValue().Set(n);
 }
 
 NAN_MODULE_INIT(Init)
@@ -29,6 +50,13 @@ NAN_MODULE_INIT(Init)
 		target,
 		Nan::New("sourceId2Coordinates").ToLocalChecked(),
 		Nan::GetFunction(Nan::New<FunctionTemplate>(sourceId2Coordinates))
+			.ToLocalChecked()
+	);
+
+	Nan::Set(
+		target,
+		Nan::New("moveMouse").ToLocalChecked(),
+		Nan::GetFunction(Nan::New<FunctionTemplate>(moveMouse))
 			.ToLocalChecked()
 	);
 }

--- a/node_addons/sourceId2Coordinates/src/sourceId2Coordinates.cc
+++ b/node_addons/sourceId2Coordinates/src/sourceId2Coordinates.cc
@@ -4,6 +4,18 @@
 
 #include "sourceId2Coordinates.h"
 
+#if defined(IS_WINDOWS)
+//Mouse motion is now done using SendInput with MOUSEINPUT. We use Absolute mouse positioning
+#define MOUSE_COORD_TO_ABS(coord, width_or_height) (65536 * (coord) / width_or_height)
+
+int vscreen_width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+int vscreen_height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+int vscreen_min_x = GetSystemMetrics(SM_XVIRTUALSCREEN);
+int vscreen_min_y = GetSystemMetrics(SM_YVIRTUALSCREEN);
+
+//DPI_AWARENESS_CONTEXT d = SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE);
+#endif
+
 /**
  * Tries to get the coordinates of a desktop from passed sourceId
  * (which identifies a desktop sharing source). Used to match the source id to a
@@ -14,9 +26,15 @@
  * NOTE: Works on windows only because on the other platforms there is an easier
  * way to match the source id and the screen.
  */
-bool sourceId2Coordinates(int sourceId, Point* res)
+bool sourceId2Coordinates(int sourceId, Point* res, int& width, int& height)
 {
 #if defined(IS_WINDOWS)
+    //Update virtual screen information before mouse moving
+    vscreen_width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+    vscreen_height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+    vscreen_min_x = GetSystemMetrics(SM_XVIRTUALSCREEN);
+    vscreen_min_y = GetSystemMetrics(SM_YVIRTUALSCREEN);
+
     DISPLAY_DEVICE device;
     device.cb = sizeof(device);
 
@@ -29,8 +47,7 @@ bool sourceId2Coordinates(int sourceId, Point* res)
     DEVMODE deviceSettings;
     deviceSettings.dmSize = sizeof(deviceSettings);
     deviceSettings.dmDriverExtra = 0;
-    if(!EnumDisplaySettingsEx(device.DeviceName, ENUM_CURRENT_SETTINGS,
-        &deviceSettings, 0))
+    if(!EnumDisplaySettingsEx(device.DeviceName, ENUM_CURRENT_SETTINGS, &deviceSettings, 0))
     {
         return false;
     }
@@ -38,8 +55,32 @@ bool sourceId2Coordinates(int sourceId, Point* res)
     res->x = deviceSettings.dmPosition.x;
     res->y = deviceSettings.dmPosition.y;
 
+    width = deviceSettings.dmPelsWidth;
+    height = deviceSettings.dmPelsHeight;
+
     return true;
 #else
     return false;
 #endif
+}
+
+/**
+ * Moves mouse on the virtual screen
+ */
+unsigned int moveMouse(int x, int y)
+{
+#if defined(IS_WINDOWS)
+	x = MOUSE_COORD_TO_ABS(x-vscreen_min_x, vscreen_width);
+	y = MOUSE_COORD_TO_ABS(y-vscreen_min_y, vscreen_height);
+	INPUT mouseInput;
+	mouseInput.type = INPUT_MOUSE;
+	mouseInput.mi.dx = x;
+	mouseInput.mi.dy = y;
+	mouseInput.mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_MOVE | MOUSEEVENTF_VIRTUALDESK;
+	mouseInput.mi.time = 0; //System will provide the timestamp
+	mouseInput.mi.dwExtraInfo = 0;
+	mouseInput.mi.mouseData = 0;
+	return SendInput(1, &mouseInput, sizeof(mouseInput));
+#endif
+    return 0;
 }

--- a/node_addons/sourceId2Coordinates/src/sourceId2Coordinates.h
+++ b/node_addons/sourceId2Coordinates/src/sourceId2Coordinates.h
@@ -4,4 +4,11 @@ struct Point {
     Point(): x(0), y(0) {};
 };
 
-bool sourceId2Coordinates(int sourceId, Point* res);
+extern int vscreen_width; //The width of the virtual screen, in pixels. 
+extern int vscreen_height; //The height of the virtual screen, in pixels. 
+extern int vscreen_min_x; //x coordinate for the left side of the virtual screen
+extern int vscreen_min_y; //y coordinate for the top of the virtual screen
+
+bool sourceId2Coordinates(int sourceId, Point* res, int& width, int& height);
+
+unsigned int moveMouse(int x, int y);


### PR DESCRIPTION
There is a error in robotjs that causes incorrect mouse position in Windows 10 with multiple displays.
RobotJS doesn't  work when displays have different dpi or placed on virtual screen randomly.