### PR TITLE
chore(deps): update robotjs fork to d870ddb

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2481,8 +2481,8 @@
       }
     },
     "robotjs": {
-      "version": "github:jitsi/robotjs#5cc469f655669e728b61271c2c57ce97d62976fd",
-      "from": "github:jitsi/robotjs#jitsi",
+      "version": "github:jitsi/robotjs#68e874397234bb4b402f6cbb7ac0788d2ae40706",
+      "from": "github:jitsi/robotjs#jitsi-d870ddb",
       "requires": {
         "nan": "^2.2.1",
         "prebuild-install": "^2.1.1"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "nan": "^2.2.1",
     "postis": "^2.2.0",
     "prebuild-install": "^2.4.1",
-    "robotjs": "jitsi/robotjs#jitsi"
+    "robotjs": "jitsi/robotjs#jitsi-d870ddb"
   },
   "devDependencies": {
     "eslint": ">=3",


### PR DESCRIPTION
This dep update brings in the jitsi fork rebased onto commit d870ddb of robotjs. The recent robotjs fixes include support for Electron 5.