### PR TITLE
Fix window resize on move

### DIFF
--- a/alwaysontop/constants.js
+++ b/alwaysontop/constants.js
@@ -1,3 +1,7 @@
 module.exports = {
-    ALWAYSONTOP_WILL_CLOSE: 'will-close'
+    ALWAYSONTOP_WILL_CLOSE: 'will-close',
+    SIZE: {
+        width: 320,
+        height: 180
+    }
 };

--- a/alwaysontop/main.js
+++ b/alwaysontop/main.js
@@ -1,11 +1,7 @@
 const os = require('os');
 const electron = require('electron');
 const { BrowserWindow, ipcMain } = electron;
-
-const SIZE = {
-    width: 320,
-    height: 180
-};
+const { SIZE } = require('./constants');
 
 /**
  * The coordinates(x and y) of the always on top window.

--- a/alwaysontop/render.js
+++ b/alwaysontop/render.js
@@ -5,7 +5,7 @@ const { EventEmitter } = require('events');
 const os = require('os');
 const path = require('path');
 
-const { ALWAYSONTOP_WILL_CLOSE } = require('./constants');
+const { ALWAYSONTOP_WILL_CLOSE, SIZE } = require('./constants');
 
 /**
  * Returieves and trying to parse a numeric value from the local storage.
@@ -257,9 +257,22 @@ class AlwaysOnTop extends EventEmitter {
              * this we'll implement drag ourselves.
              */
             shouldImplementDrag: os.type() !== 'Darwin',
+            /**
+             * Custom implementation for window move.
+             * We use setBounds in order to preserve the initial size of the window
+             * during drag. This is in order to fix:
+             * https://github.com/electron/electron/issues/9477
+             * @param x
+             * @param y
+             */
             move: (x, y) => {
                 if (this._alwaysOnTopBrowserWindow) {
-                    this._alwaysOnTopBrowserWindow.setPosition(x, y);
+                    this._alwaysOnTopBrowserWindow.setBounds({
+                        x,
+                        y,
+                        width: SIZE.width,
+                        height: SIZE.height
+                    });
                 }
             }
         };


### PR DESCRIPTION
This fixes :
https://github.com/electron/electron/issues/9477

On monitors having scale options applied,window.setPosition() also cause a growth of the window. 
The fix consists in resetting to initial window size once the move/drag event finished.
This only applies on Windows.