### PR TITLE
Add screen sharing tracker window

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,30 @@ NOTE: `dispose` method will be called automatically when the Jitsi Meet iframe u
 The screen sharing utility requires iframe HTML Element that will load Jitsi Meet.
 
 **Enable the screen sharing:**
+
+In the **render** electron process of the window where Jitsi Meet is displayed:
+
 ```Javascript
 const {
-    setupScreenSharingForWindow
+    setupScreenSharingRender
 } = require("jitsi-meet-electron-utils");
 
-// iframe - the Jitsi Meet iframe
-setupScreenSharingForWindow(iframe);
+// api - The Jitsi Meet iframe api object.
+setupScreenSharingRender(api);
 ```
+In the **main** electron process:
+
+```Javascript
+const {
+    setupScreenSharingMain
+} = require("jitsi-meet-electron-utils");
+
+// jitsiMeetWindow - The BrowserWindow instance of the window where Jitsi Meet is loaded.
+// appName - Application name which will be displayed inside the content sharing tracking window
+// i.e. [appName] is sharing your screen.
+setupScreenSharingMain(mainWindow, appName);
+```
+
 
 #### Always On Top
 Displays a small window with the current active speaker video when the main Jitsi Meet window is not focused.

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const RemoteControl = require('./remotecontrol');
-const {setupScreenSharingForWindow, setupScreenSharingMain} = require('./screensharing');
+const { setupScreenSharingForWindow, setupScreenSharingMain } = require('./screensharing');
 const {
     setupAlwaysOnTopRender,
     setupAlwaysOnTopMain

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const RemoteControl = require('./remotecontrol');
-const setupScreenSharingForWindow = require('./screensharing');
+const {setupScreenSharingForWindow, setupScreenSharingMain} = require('./screensharing');
 const {
     setupAlwaysOnTopRender,
     setupAlwaysOnTopMain
@@ -17,6 +17,7 @@ module.exports = {
     getWiFiStats,
     RemoteControl,
     setupScreenSharingForWindow,
+    setupScreenSharingMain,
     setupAlwaysOnTopRender,
     setupAlwaysOnTopMain,
     setupPowerMonitorRender,

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const RemoteControl = require('./remotecontrol');
-const { setupScreenSharingForWindow, setupScreenSharingMain } = require('./screensharing');
+const { setupScreenSharingRender, setupScreenSharingMain } = require('./screensharing');
 const {
     setupAlwaysOnTopRender,
     setupAlwaysOnTopMain
@@ -16,7 +16,7 @@ const {
 module.exports = {
     getWiFiStats,
     RemoteControl,
-    setupScreenSharingForWindow,
+    setupScreenSharingRender,
     setupScreenSharingMain,
     setupAlwaysOnTopRender,
     setupAlwaysOnTopMain,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jitsi-meet-electron-utils",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jitsi-meet-electron-utils",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "Utilities for jitsi-meet-electron project",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jitsi-meet-electron-utils",
-  "version": "1.1.1",
+  "version": "1.2.1",
   "description": "Utilities for jitsi-meet-electron project",
   "main": "index.js",
   "scripts": {

--- a/screensharing/constants.js
+++ b/screensharing/constants.js
@@ -1,0 +1,29 @@
+/**
+ * The name of the channel that exchange events between render and main process.
+ * @type {string}
+ */
+const SCREEN_SHARE_EVENTS_CHANNEL = 'jitsi-screen-sharing-marker';
+
+/**
+ * Size of the screen sharing tracker window.
+ */
+const TRACKER_SIZE = {
+    height: 40,
+    width: 490.
+};
+
+/**
+ * Possible events passed on the SCREEN_SHARE_EVENTS_CHANNEL.
+ */
+const SCREEN_SHARE_EVENTS = {
+    OPEN_TRACKER: 'open-tracker-window' ,
+    CLOSE_TRACKER: 'close-tracker-window',
+    STOP_SCREEN_SHARE: 'stop-screen-share'
+};
+
+module.exports = {
+    SCREEN_SHARE_EVENTS_CHANNEL,
+    SCREEN_SHARE_EVENTS,
+    TRACKER_SIZE
+};
+

--- a/screensharing/index.js
+++ b/screensharing/index.js
@@ -1,45 +1,7 @@
-/* global process */
+const setupScreenSharingMain = require('./main');
+const setupScreenSharingForWindow = require('./render');
 
-const electron = require("electron");
-const semver = require('semver');
-
-module.exports = function setupScreenSharingForWindow(iframe) {
-    // make sure that even after reload/redirect the screensharing will be
-    // available
-    iframe.addEventListener('load', () => {
-        iframe.contentWindow.JitsiMeetElectron = {
-            /**
-             * Get sources available for screensharing. The callback is invoked
-             * with an array of DesktopCapturerSources.
-             *
-             * @param {Function} callback - The success callback.
-             * @param {Function} errorCallback - The callback for errors.
-             * @param {Object} options - Configuration for getting sources.
-             * @param {Array} options.types - Specify the desktop source types
-             * to get, with valid sources being "window" and "screen".
-             * @param {Object} options.thumbnailSize - Specify how big the
-             * preview images for the sources should be. The valid keys are
-             * height and width, e.g. { height: number, width: number}. By
-             * default electron will return images with height and width of
-             * 150px.
-             */
-            obtainDesktopStreams(callback, errorCallback, options = {}) {
-                if (semver.lt(process.versions.electron, '5.0.0')) {
-                    electron.desktopCapturer.getSources(options,
-                        (error, sources) => {
-                            if (error) {
-                                errorCallback(error);
-                                return;
-                            }
-
-                            callback(sources);
-                        });
-                } else {
-                    electron.desktopCapturer.getSources(options)
-                        .then(sources => callback(sources))
-                        .catch(error => errorCallback(error));
-                }
-            }
-        };
-    });
+module.exports = {
+    setupScreenSharingMain,
+    setupScreenSharingForWindow
 };

--- a/screensharing/index.js
+++ b/screensharing/index.js
@@ -1,7 +1,7 @@
 const setupScreenSharingMain = require('./main');
-const setupScreenSharingForWindow = require('./render');
+const setupScreenSharingRender = require('./render');
 
 module.exports = {
     setupScreenSharingMain,
-    setupScreenSharingForWindow
+    setupScreenSharingRender
 };

--- a/screensharing/main.js
+++ b/screensharing/main.js
@@ -1,0 +1,112 @@
+const { app, BrowserWindow, ipcMain, screen } = require('electron');
+
+const { SCREEN_SHARE_EVENTS_CHANNEL, SCREEN_SHARE_EVENTS, TRACKER_SIZE } = require('./constants');
+
+/**
+ * Main process component that sets up electron specific screen sharing functionality, like screen sharing
+ * tracker and window selection.
+ * The class will process events from {@link ScreenShareRenderHook} initialized in the renderer, and the
+ * always on top screen sharing tracker window.
+ */
+class ScreenShareMainHook {
+    /**
+     * Create ScreenShareMainHook linked to jitsiMeetWindow.
+     *
+     * @param {BrowserWindow} jitsiMeetWindow - BrowserWindow where jitsi-meet api is loaded.
+     * @param {string} identity - Name of the application doing screen sharing, will be displayed in the
+     * screen sharing tracker window text i.e. {identity} is sharing your screen.
+     */
+    constructor(jitsiMeetWindow, identity) {
+        this._jitsiMeetWindow = jitsiMeetWindow;
+        this._identity = identity;
+        this._onScreenSharingEvent = this._onScreenSharingEvent.bind(this);
+
+        // Listen for events coming in from the main render window and the screen share tracker window.
+        ipcMain.on(SCREEN_SHARE_EVENTS_CHANNEL, this._onScreenSharingEvent);
+
+        // Clean up ipcMain handlers to avoid leaks.
+        app.once('window-all-closed', () => {
+            ipcMain.removeListener(SCREEN_SHARE_EVENTS_CHANNEL, this._onScreenSharingEvent);
+        });
+    }
+
+    /**
+     * Listen for events coming on the screen sharing event channel.
+     *
+     * @param {Object} event - Electron event data.
+     * @param {Object} data - Channel specific data.
+     */
+    _onScreenSharingEvent(event, { data }) {
+        switch (data.name) {
+            case SCREEN_SHARE_EVENTS.OPEN_TRACKER:
+                this._createScreenShareTracker();
+                break;
+            case SCREEN_SHARE_EVENTS.CLOSE_TRACKER:
+                if (this._screenShareTracker) {
+                    this._screenShareTracker.close();
+                    this._screenShareTracker = undefined;
+                }
+                break;
+            case SCREEN_SHARE_EVENTS.STOP_SCREEN_SHARE:
+                this._jitsiMeetWindow.webContents.send(SCREEN_SHARE_EVENTS_CHANNEL, { data });
+                break;
+            default:
+                console.warn(`Unhandled ${SCREEN_SHARE_EVENTS_CHANNEL}: ${data}`);
+        }
+    }
+
+    /**
+     * Opens an always on top window, in the bottom center of the screen, that lets a user know
+     * a content sharing session is currently active.
+     *
+     * @return {void}
+     */
+    _createScreenShareTracker() {
+        if (this._screenShareTracker) {
+            return;
+        }
+
+        // Display always on top screen sharing tracker window in the center bottom of the screen.
+        let display = screen.getPrimaryDisplay();
+        this._screenShareTracker = new BrowserWindow({
+            height: TRACKER_SIZE.height,
+            width: TRACKER_SIZE.width,
+            x:(display.bounds.width - TRACKER_SIZE.width) / 2,
+            y:display.bounds.height - TRACKER_SIZE.height - 10,
+            transparent: true,
+            minimizable: true,
+            maximizable: false,
+            resizable: false,
+            alwaysOnTop: true,
+            fullscreen: false,
+            fullscreenable: false,
+            skipTaskbar: true,
+            frame: false,
+            show: false,
+            webPreferences: {
+                nodeIntegration: true
+            }
+        });
+
+        // Prevent newly created window to take focus from main application.
+        this._screenShareTracker.once('ready-to-show', () => {
+            if (this._screenShareTracker && !this._screenShareTracker.isDestroyed()) {
+                this._screenShareTracker.showInactive();
+            }
+        });
+
+        this._screenShareTracker.sharingIdentity = this._identity;
+        this._screenShareTracker.loadURL(`file://${__dirname}/screenSharingTracker.html?`);
+    }
+}
+
+/**
+ * Initializes the screen sharing electron specific functionality in the main electron process.
+ *
+ * @param {BrowserWindow} jitsiMeetWindow - the BrowserWindow object which displays Jitsi Meet
+ * @param {string} identity - Name of the application doing screen sharing, will be displayed in the
+ * screen sharing tracker window text i.e. {identity} is sharing your screen.
+ */
+module.exports = function setupScreenSharingMain(jitsiMeetWindow, identity) {
+    return new ScreenShareMainHook(jitsiMeetWindow, identity);
+};

--- a/screensharing/main.js
+++ b/screensharing/main.js
@@ -96,8 +96,8 @@ class ScreenShareMainHook {
             }
         });
 
-        this._screenShareTracker.sharingIdentity = this._identity;
-        this._screenShareTracker.loadURL(`file://${__dirname}/screenSharingTracker.html?`);
+        this._screenShareTracker
+            .loadURL(`file://${__dirname}/screenSharingTracker.html?sharingIdentity=${this._identity}`);
     }
 }
 

--- a/screensharing/main.js
+++ b/screensharing/main.js
@@ -96,6 +96,7 @@ class ScreenShareMainHook {
         });
 
         this._screenShareTracker.sharingIdentity = this._identity;
+        // eslint-disable-next-line no-undef
         this._screenShareTracker.loadURL(`file://${__dirname}/screenSharingTracker.html?`);
     }
 }

--- a/screensharing/main.js
+++ b/screensharing/main.js
@@ -1,4 +1,5 @@
-const { app, BrowserWindow, ipcMain, screen } = require('electron');
+/* global __dirname */
+const electron = require('electron');
 
 const { SCREEN_SHARE_EVENTS_CHANNEL, SCREEN_SHARE_EVENTS, TRACKER_SIZE } = require('./constants');
 
@@ -22,11 +23,11 @@ class ScreenShareMainHook {
         this._onScreenSharingEvent = this._onScreenSharingEvent.bind(this);
 
         // Listen for events coming in from the main render window and the screen share tracker window.
-        ipcMain.on(SCREEN_SHARE_EVENTS_CHANNEL, this._onScreenSharingEvent);
+        electron.ipcMain.on(SCREEN_SHARE_EVENTS_CHANNEL, this._onScreenSharingEvent);
 
         // Clean up ipcMain handlers to avoid leaks.
-        app.once('window-all-closed', () => {
-            ipcMain.removeListener(SCREEN_SHARE_EVENTS_CHANNEL, this._onScreenSharingEvent);
+        this._jitsiMeetWindow.on('closed', () => {
+            electron.ipcMain.removeListener(SCREEN_SHARE_EVENTS_CHANNEL, this._onScreenSharingEvent);
         });
     }
 
@@ -67,8 +68,8 @@ class ScreenShareMainHook {
         }
 
         // Display always on top screen sharing tracker window in the center bottom of the screen.
-        let display = screen.getPrimaryDisplay();
-        this._screenShareTracker = new BrowserWindow({
+        let display = electron.screen.getPrimaryDisplay();
+        this._screenShareTracker = new electron.BrowserWindow({
             height: TRACKER_SIZE.height,
             width: TRACKER_SIZE.width,
             x:(display.bounds.width - TRACKER_SIZE.width) / 2,
@@ -96,7 +97,6 @@ class ScreenShareMainHook {
         });
 
         this._screenShareTracker.sharingIdentity = this._identity;
-        // eslint-disable-next-line no-undef
         this._screenShareTracker.loadURL(`file://${__dirname}/screenSharingTracker.html?`);
     }
 }

--- a/screensharing/render.js
+++ b/screensharing/render.js
@@ -15,14 +15,11 @@ class ScreenShareRenderHook {
     /**
      * Creates a ScreenShareRenderHook hooked to jitsi meet iframe events.
      *
-     * @param {iframe} iframe - The jitsi Meet iframe object. This may seem redundant as we can access it from
-     * the api object, however we need it here for backwards compatibility as some clients are setup is such a
-     * way that they may end up calling the old jitsi-meet-electron-utils with the updated api, causing crashes.
      * @param {JitsiIFrameApi} api - The Jitsi Meet iframe api object.
      */
-    constructor(iframe, api) {
+    constructor(api) {
         this._api = api;
-        this._iframe = iframe;
+        this._iframe = this._api.getIFrame();
 
         this._onScreenSharingStatusChanged = this._onScreenSharingStatusChanged.bind(this);
         this._sendCloseTrackerEvent = this._sendCloseTrackerEvent.bind(this);
@@ -156,9 +153,8 @@ class ScreenShareRenderHook {
  * Initializes the screen sharing electron specific functionality in the renderer process containing the
  * jitsi meet iframe.
  *
- * @param {iframe} iframe - The jitsi Meet iframe object.
  * @param {JitsiIFrameApi} api - The Jitsi Meet iframe api object.
  */
-module.exports = function setupScreenSharingForWindow(iframe, api) {
-    return new ScreenShareRenderHook(iframe, api);
+module.exports = function setupScreenSharingRender(api) {
+    return new ScreenShareRenderHook(api);
 };

--- a/screensharing/render.js
+++ b/screensharing/render.js
@@ -1,0 +1,160 @@
+/* global process */
+
+const { ipcRenderer, desktopCapturer } = require('electron');
+const semver = require('semver');
+
+const { SCREEN_SHARE_EVENTS_CHANNEL, SCREEN_SHARE_EVENTS } = require('./constants');
+
+/**
+ * Renderer process component that sets up electron specific screen sharing functionality, like screen sharing
+ * marker and window selection.
+ * {@link ScreenShareMainHook} needs to be initialized in the main process for the always on top tracker window
+ * to work.
+ */
+class ScreenShareRenderHook {
+    /**
+     * Creates a ScreenShareRenderHook hooked to jitsi meet iframe events.
+     *
+     * @param {JitsiIFrameApi} api - The Jitsi Meet iframe api object.
+     */
+    constructor(api) {
+        this._api = api;
+        this._iframe = this._api.getIFrame();
+
+        this._onScreenSharingStatusChanged = this._onScreenSharingStatusChanged.bind(this);
+        this._sendCloseTrackerEvent = this._sendCloseTrackerEvent.bind(this);
+        this._onScreenSharingEvent = this._onScreenSharingEvent.bind(this);
+        this._onIframeApiLoad = this._onIframeApiLoad.bind(this);
+        this._cleanContext = this._cleanContext.bind(this);
+
+        ipcRenderer.on(SCREEN_SHARE_EVENTS_CHANNEL, this._onScreenSharingEvent);
+        this._api.on('screenSharingStatusChanged', this._onScreenSharingStatusChanged);
+        this._api.on('videoConferenceLeft', this._cleanContext);
+        this._api.on('_willDispose', this._cleanContext);
+        this._iframe.addEventListener('load', this._onIframeApiLoad);
+    }
+
+    /**
+     * Make sure that even after reload/redirect the screensharing will be available
+     */
+    _onIframeApiLoad() {
+        this._iframe.contentWindow.JitsiMeetElectron = {
+            /**
+             * Get sources available for screensharing. The callback is invoked
+             * with an array of DesktopCapturerSources.
+             *
+             * @param {Function} callback - The success callback.
+             * @param {Function} errorCallback - The callback for errors.
+             * @param {Object} options - Configuration for getting sources.
+             * @param {Array} options.types - Specify the desktop source types
+             * to get, with valid sources being "window" and "screen".
+             * @param {Object} options.thumbnailSize - Specify how big the
+             * preview images for the sources should be. The valid keys are
+             * height and width, e.g. { height: number, width: number}. By
+             * default electron will return images with height and width of
+             * 150px.
+             */
+            obtainDesktopStreams(callback, errorCallback, options = {}) {
+                if (semver.lt(process.versions.electron, '5.0.0')) {
+                    desktopCapturer.getSources(options, (error, sources) => {
+                        if (error) {
+                            errorCallback(error);
+                            return;
+                        }
+
+                        callback(sources);
+                    });
+                } else {
+                    desktopCapturer
+                        .getSources(options)
+                        .then((sources) => callback(sources))
+                        .catch((error) => errorCallback(error));
+                }
+            }
+        };
+    }
+
+    /**
+     * Listen for events coming on the screen sharing event channel.
+     *
+     * @param {Object} event - Electron event data.
+     * @param {Object} data - Channel specific data.
+     *
+     * @returns {void}
+     */
+    _onScreenSharingEvent(event, { data }) {
+        switch (data.name) {
+            // Event send by the screen sharing tracker window when a user stops screen sharing from it.
+            // Send appropriate command to jitsi meet api.
+            case SCREEN_SHARE_EVENTS.STOP_SCREEN_SHARE:
+                if (this._isScreenSharing) {
+                    this._api.executeCommand('toggleShareScreen');
+                }
+                break;
+            default:
+                console.warn(`Unhandled ${SCREEN_SHARE_EVENTS_CHANNEL}: ${data}`);
+
+        }
+    }
+
+    /**
+     * React to screen sharing events coming from the jitsi meet api. There should be
+     * a {@link ScreenShareMainHook} listening on the main process for the forwarded events.
+     *
+     * @param {Object} event
+     *
+     * @returns {void}
+     */
+    _onScreenSharingStatusChanged(event) {
+        if (event.on) {
+            this._isScreenSharing = true;
+            // Send event which should open an always on top tracker window from the main process.
+            ipcRenderer.send(SCREEN_SHARE_EVENTS_CHANNEL, {
+                data: {
+                    name: SCREEN_SHARE_EVENTS.OPEN_TRACKER
+                }
+            });
+        } else {
+            this._isScreenSharing = false;
+            this._sendCloseTrackerEvent();
+        }
+    }
+
+    /**
+     * Send event which should close the always on top tracker window.
+     *
+     * @return {void}
+     */
+    _sendCloseTrackerEvent() {
+        ipcRenderer.send(SCREEN_SHARE_EVENTS_CHANNEL, {
+            data: {
+                name: SCREEN_SHARE_EVENTS.CLOSE_TRACKER
+            }
+        });
+    }
+
+    /**
+     * Clear all event handler in order to avoid any potential leaks and close the screen sharing tracker
+     * window in the event that it's currently being displayed.
+     *
+     * @returns {void}
+     */
+    _cleanContext() {
+        ipcRenderer.removeListener(SCREEN_SHARE_EVENTS_CHANNEL, this._onScreenSharingEvent);
+        this._api.removeListener('screenSharingStatusChanged', this._onScreenSharingStatusChanged);
+        this._api.removeListener('videoConferenceLeft', this._sendCloseTrackerEvent);
+        this._api.removeListener('_willDispose', this._sendCloseTrackerEvent);
+        this._iframe.removeEventListener('load', this._onIframeApiLoad);
+        this._sendCloseTrackerEvent();
+    }
+}
+
+/**
+ * Initializes the screen sharing electron specific functionality in the renderer process containing the
+ * jitsi meet iframe.
+ *
+ * @param {JitsiIFrameApi} api - The Jitsi Meet iframe api object.
+ */
+module.exports = function setupScreenSharingForWindow(api) {
+    return new ScreenShareRenderHook(api);
+};

--- a/screensharing/render.js
+++ b/screensharing/render.js
@@ -15,11 +15,14 @@ class ScreenShareRenderHook {
     /**
      * Creates a ScreenShareRenderHook hooked to jitsi meet iframe events.
      *
+     * @param {iframe} iframe - The jitsi Meet iframe object. This may seem redundant as we can access it from
+     * the api object, however we need it here for backwards compatibility as some clients are setup is such a
+     * way that they may end up calling the old jitsi-meet-electron-utils with the updated api, causing crashes.
      * @param {JitsiIFrameApi} api - The Jitsi Meet iframe api object.
      */
-    constructor(api) {
+    constructor(iframe, api) {
         this._api = api;
-        this._iframe = this._api.getIFrame();
+        this._iframe = iframe;
 
         this._onScreenSharingStatusChanged = this._onScreenSharingStatusChanged.bind(this);
         this._sendCloseTrackerEvent = this._sendCloseTrackerEvent.bind(this);
@@ -153,8 +156,9 @@ class ScreenShareRenderHook {
  * Initializes the screen sharing electron specific functionality in the renderer process containing the
  * jitsi meet iframe.
  *
+ * @param {iframe} iframe - The jitsi Meet iframe object.
  * @param {JitsiIFrameApi} api - The Jitsi Meet iframe api object.
  */
-module.exports = function setupScreenSharingForWindow(api) {
-    return new ScreenShareRenderHook(api);
+module.exports = function setupScreenSharingForWindow(iframe, api) {
+    return new ScreenShareRenderHook(iframe, api);
 };

--- a/screensharing/screenSharingTracker.html
+++ b/screensharing/screenSharingTracker.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>Screen Sharing Tracker</title>
+  <style>
+    html {
+      background-color: #303135e6;
+    }
+
+    body {
+      align-items: center;
+      color: #e4e4e4;
+      display: flex;
+      justify-content: space-between;
+      margin: 0;
+      padding: 6px 16px;
+      -webkit-user-select: none;
+      -webkit-app-region: drag;
+    }
+
+    button {
+      background-color: #b8b8b8;
+      border: 0;
+      border-radius: 4px;
+      color: #282a2f;
+      height: 28px;
+      margin-right: 16px;
+    }
+
+    #text-container {
+      font-family:Arial, Helvetica, sans-serif;
+      font-size: 13px;
+      display: flex;
+    }
+
+    #double-line {
+      font-size: 15px;
+      font-weight:bolder;
+    }
+
+    #screen-share-marker-minimize {
+      color: #ababab;
+      font-family:Arial, Helvetica, sans-serif;
+      font-size: 13px;
+    }
+
+    #sharing-identity {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      max-width: 170px;
+    }
+  </style>
+</head>
+
+<body>
+  <span id="double-line">‖</span>
+  <div id="text-container">
+    <span id="sharing-identity"></span><span id="static-text">&nbsp;is sharing your screen.</span>
+  </div>
+  <div>
+    <button id="screen-share-marker-stop">Stop sharing</button>
+    <a id="screen-share-marker-minimize">Hide</a>
+  </div>
+  <script src="screenSharingTracker.js"></script>
+</body>
+
+</html>

--- a/screensharing/screenSharingTracker.js
+++ b/screensharing/screenSharingTracker.js
@@ -1,4 +1,5 @@
 const { ipcRenderer, remote } = require('electron');
+const querystring = require('querystring');
 
 const { SCREEN_SHARE_EVENTS_CHANNEL, SCREEN_SHARE_EVENTS } = require('./constants');
 
@@ -6,7 +7,7 @@ const screenShareStop = document.getElementById("screen-share-marker-stop");
 const screenShareMinimize = document.getElementById("screen-share-marker-minimize");
 const sharingIdentity = document.getElementById("sharing-identity");
 
-sharingIdentity.innerHTML = remote.getCurrentWindow().sharingIdentity;
+sharingIdentity.innerHTML = querystring.parse(global.location.search)['?sharingIdentity'];
 
 /**
  * Minimize the window.

--- a/screensharing/screenSharingTracker.js
+++ b/screensharing/screenSharingTracker.js
@@ -1,0 +1,30 @@
+const {ipcRenderer, remote} = require('electron');
+
+const {SCREEN_SHARE_EVENTS_CHANNEL, SCREEN_SHARE_EVENTS} = require('./constants');
+
+
+const screenShareStop = document.getElementById("screen-share-marker-stop");
+const screenShareMinimize = document.getElementById("screen-share-marker-minimize");
+const sharingIdentity = document.getElementById("sharing-identity");
+
+sharingIdentity.innerHTML = remote.getCurrentWindow().sharingIdentity;
+
+/**
+ * Minimize the window.
+ */
+screenShareMinimize.addEventListener("click",function() {
+    remote.BrowserWindow.getFocusedWindow().minimize();
+});
+
+/**
+ * When the user clicks the stop button, send a message that will eventually be processed by
+ * {@link ScreenShareRenderHook} which will toggle the screen sharing session using the jitsi-meet api.
+ */
+screenShareStop.addEventListener("click",function() {
+    ipcRenderer.send(SCREEN_SHARE_EVENTS_CHANNEL, {
+        data: {
+            name: SCREEN_SHARE_EVENTS.STOP_SCREEN_SHARE
+        }
+    });
+});
+

--- a/screensharing/screenSharingTracker.js
+++ b/screensharing/screenSharingTracker.js
@@ -1,7 +1,6 @@
-const {ipcRenderer, remote} = require('electron');
+const { ipcRenderer, remote } = require('electron');
 
-const {SCREEN_SHARE_EVENTS_CHANNEL, SCREEN_SHARE_EVENTS} = require('./constants');
-
+const { SCREEN_SHARE_EVENTS_CHANNEL, SCREEN_SHARE_EVENTS } = require('./constants');
 
 const screenShareStop = document.getElementById("screen-share-marker-stop");
 const screenShareMinimize = document.getElementById("screen-share-marker-minimize");
@@ -12,7 +11,7 @@ sharingIdentity.innerHTML = remote.getCurrentWindow().sharingIdentity;
 /**
  * Minimize the window.
  */
-screenShareMinimize.addEventListener("click",function() {
+screenShareMinimize.addEventListener("click", function() {
     remote.BrowserWindow.getFocusedWindow().minimize();
 });
 
@@ -20,7 +19,7 @@ screenShareMinimize.addEventListener("click",function() {
  * When the user clicks the stop button, send a message that will eventually be processed by
  * {@link ScreenShareRenderHook} which will toggle the screen sharing session using the jitsi-meet api.
  */
-screenShareStop.addEventListener("click",function() {
+screenShareStop.addEventListener("click", function() {
     ipcRenderer.send(SCREEN_SHARE_EVENTS_CHANNEL, {
         data: {
             name: SCREEN_SHARE_EVENTS.STOP_SCREEN_SHARE


### PR DESCRIPTION
Functionality that will create an always on top window in bottom center of the screen whenever the user start a content sharing session.
The purpose is to let the user know he is sharing his screen.