### PR TITLE
Fix screen-share tracker on Windows 10 OS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jitsi-meet-electron-utils",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jitsi-meet-electron-utils",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Utilities for jitsi-meet-electron project",
   "main": "index.js",
   "scripts": {

--- a/screensharing/constants.js
+++ b/screensharing/constants.js
@@ -9,7 +9,7 @@ const SCREEN_SHARE_EVENTS_CHANNEL = 'jitsi-screen-sharing-marker';
  */
 const TRACKER_SIZE = {
     height: 40,
-    width: 490.
+    width: 530.
 };
 
 /**

--- a/screensharing/main.js
+++ b/screensharing/main.js
@@ -89,8 +89,6 @@ class ScreenShareMainHook {
             }
         });
 
-        this._screenShareTracker.openDevTools();
-        
         // Prevent newly created window to take focus from main application.
         this._screenShareTracker.once('ready-to-show', () => {
             if (this._screenShareTracker && !this._screenShareTracker.isDestroyed()) {

--- a/screensharing/main.js
+++ b/screensharing/main.js
@@ -72,8 +72,8 @@ class ScreenShareMainHook {
         this._screenShareTracker = new electron.BrowserWindow({
             height: TRACKER_SIZE.height,
             width: TRACKER_SIZE.width,
-            x:(display.bounds.width - TRACKER_SIZE.width) / 2,
-            y:display.bounds.height - TRACKER_SIZE.height - 10,
+            x:(display.workArea.width - TRACKER_SIZE.width) / 2,
+            y:display.workArea.height - TRACKER_SIZE.height - 10,
             transparent: true,
             minimizable: true,
             maximizable: false,
@@ -81,7 +81,7 @@ class ScreenShareMainHook {
             alwaysOnTop: true,
             fullscreen: false,
             fullscreenable: false,
-            skipTaskbar: true,
+            skipTaskbar: false,
             frame: false,
             show: false,
             webPreferences: {

--- a/screensharing/main.js
+++ b/screensharing/main.js
@@ -73,7 +73,7 @@ class ScreenShareMainHook {
             height: TRACKER_SIZE.height,
             width: TRACKER_SIZE.width,
             x:(display.workArea.width - TRACKER_SIZE.width) / 2,
-            y:display.workArea.height - TRACKER_SIZE.height - 10,
+            y:display.workArea.height - TRACKER_SIZE.height - 5,
             transparent: true,
             minimizable: true,
             maximizable: false,
@@ -89,6 +89,8 @@ class ScreenShareMainHook {
             }
         });
 
+        this._screenShareTracker.openDevTools();
+        
         // Prevent newly created window to take focus from main application.
         this._screenShareTracker.once('ready-to-show', () => {
             if (this._screenShareTracker && !this._screenShareTracker.isDestroyed()) {

--- a/screensharing/screenSharingTracker.html
+++ b/screensharing/screenSharingTracker.html
@@ -18,7 +18,7 @@
       margin: 0;
       padding: 6px 16px;
       -webkit-user-select: none;
-      -webkit-app-region: drag;
+      -webkit-app-region: drag; 
     }
 
     button {
@@ -28,6 +28,7 @@
       color: #282a2f;
       height: 28px;
       margin-right: 16px;
+      -webkit-app-region: no-drag;
     }
 
     #text-container {
@@ -45,6 +46,7 @@
       color: #ababab;
       font-family:Arial, Helvetica, sans-serif;
       font-size: 13px;
+      -webkit-app-region: no-drag;
     }
 
     #sharing-identity {

--- a/screensharing/screenSharingTracker.html
+++ b/screensharing/screenSharingTracker.html
@@ -18,7 +18,7 @@
       margin: 0;
       padding: 6px 16px;
       -webkit-user-select: none;
-      -webkit-app-region: drag; 
+      -webkit-app-region: drag;
     }
 
     button {


### PR DESCRIPTION
On Windows we need to specify `-webkit-app-region: no-drag;` for elements of a draggable window in order to interact with them, i.e. the Stop sharing button in our case.
Also from time to time some sort of provisory font is loaded before the css specified one, which caused text shift one line, giving the window more width seems to fix this problem.