### PR TITLE
Keep AoT window open during meeting: hide & show insetad of close & open

### DIFF
--- a/screensharing/main.js
+++ b/screensharing/main.js
@@ -89,6 +89,10 @@ class ScreenShareMainHook {
             }
         });
 
+        this._screenShareTracker.on('closed', () => {
+            this._screenShareTracker = undefined;
+        });
+
         // Prevent newly created window to take focus from main application.
         this._screenShareTracker.once('ready-to-show', () => {
             if (this._screenShareTracker && !this._screenShareTracker.isDestroyed()) {


### PR DESCRIPTION
Workaround for electron crashing (strictly a crash, but a failure that ends in the app being forcefully closed) when AoT window is quickly closed and opened during both a focus (main window) and navigate away from the meeting page on Windows.

I would also only hide on dbclick but this breaks current integration as navigating is only one on close.

I also have some performance concerns as the AoT window will still be open and video is piped to it even when it's not visible, I haven't deeply looked into also tackling this potential perf issue.