### PR TITLE
Fix for missing browserWindow after closing the windows on osx

### DIFF
--- a/powermonitor/main.js
+++ b/powermonitor/main.js
@@ -19,7 +19,7 @@ function _attachEvents(jitsiMeetWindow) {
     browserWindow = jitsiMeetWindow;
     Object.values(POWER_MONITOR_EVENTS).forEach(event => {
         electron.powerMonitor.on(event, () => {
-            if (!this.browserWindow || this.browserWindow.isDestroyed()) {
+            if (!browserWindow || !browserWindow.isDestroyed()) {
                 browserWindow.webContents.send(POWER_MONITOR_EVENTS_CHANNEL, { event });
             }
         });

--- a/powermonitor/main.js
+++ b/powermonitor/main.js
@@ -19,7 +19,9 @@ function _attachEvents(jitsiMeetWindow) {
     browserWindow = jitsiMeetWindow;
     Object.values(POWER_MONITOR_EVENTS).forEach(event => {
         electron.powerMonitor.on(event, () => {
-            jitsiMeetWindow.webContents.send(POWER_MONITOR_EVENTS_CHANNEL, { event });
+            if (!this.browserWindow || this.browserWindow.isDestroyed()) {
+                browserWindow.webContents.send(POWER_MONITOR_EVENTS_CHANNEL, { event });
+            }
         });
     });
 }


### PR DESCRIPTION
A fix for a bug, which occurs after closing the jitsi window on Mac osx:

<img width="547" alt="screenshot_bug" src="https://user-images.githubusercontent.com/1164655/79240006-85d5b180-7e71-11ea-9665-f7b03ca87c74.png">

Also used the variable `browserWindow` instead of `jitsiMeetWindow` - seems more consistent.