### PR TITLE
fix(AOT): will close event.

### DIFF
--- a/alwaysontop/main.js
+++ b/alwaysontop/main.js
@@ -86,7 +86,7 @@ function onAlwaysOnTopWindow(
 
         win.webContents.on('error', error => {
             console.warn(error, 'Unhandled AOT webContents error');
-        })
+        });
 
         setAspectRatioToResizeableWindow(win, ASPECT_RATIO);
 

--- a/alwaysontop/render.js
+++ b/alwaysontop/render.js
@@ -298,7 +298,7 @@ class AlwaysOnTop extends EventEmitter {
                 );
             },
             ondblclick: () => {
-                this._closeAlwaysOnTopWindow();
+                this._hideAlwaysOnTopWindow();
                 this._jitsiMeetElectronWindow.show();
             },
             /**
@@ -425,11 +425,11 @@ class AlwaysOnTop extends EventEmitter {
      * @returns {void}
      */
     _showAlwaysOnTopWindow() {
-      if (exists(this._alwaysOnTopBrowserWindow)) {
-        try {
-          this._alwaysOnTopBrowserWindow.showInactive();
-        } catch (ignore) {}
-      }
+        if (exists(this._alwaysOnTopBrowserWindow)) {
+            try {
+                this._alwaysOnTopBrowserWindow.showInactive();
+            } catch (ignore) {}
+        }
     }
 
     /**
@@ -438,11 +438,12 @@ class AlwaysOnTop extends EventEmitter {
      * @returns {void}
      */
     _hideAlwaysOnTopWindow() {
-      if (exists(this._alwaysOnTopBrowserWindow)) {
-        try {
-          this._alwaysOnTopBrowserWindow.hide();
-        } catch (ignore) {}
-      }
+        if (exists(this._alwaysOnTopBrowserWindow)) {
+            this.emit(ALWAYSONTOP_WILL_CLOSE);
+            try {
+                this._alwaysOnTopBrowserWindow.hide();
+            } catch (ignore) {}
+        }
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jitsi-meet-electron-utils",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jitsi-meet-electron-utils",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "Utilities for jitsi-meet-electron project",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
@andreieftimie After merging https://github.com/jitsi/jitsi-meet-electron-utils/pull/72 I realised that actually we have broken the will-close event. This PR brings back the original behaviour of the event. Since it is abstract event I'm triggering it for the use cases when we hide the AOT. In addition I realised that this would probably solve the issue you described for the double click. That's why I also changed the double click to hide AOT instead of close it.

Could you please verify that this will work for your use case?