### PR TITLE
Fix AoT close race condition

### DIFF
--- a/alwaysontop/render.js
+++ b/alwaysontop/render.js
@@ -317,12 +317,14 @@ class AlwaysOnTop extends EventEmitter {
              */
             move: (x, y, initialSize) => {
                 if (this._alwaysOnTopBrowserWindow) {
-                    this._alwaysOnTopBrowserWindow.setBounds({
-                        x,
-                        y,
-                        width: initialSize.width,
-                        height: initialSize.height
-                    });
+                    try {
+                        this._alwaysOnTopBrowserWindow.setBounds({
+                            x,
+                            y,
+                            width: initialSize.width,
+                            height: initialSize.height
+                        });
+                    } catch (ignore) {}
                 }
             },
             /**
@@ -331,8 +333,10 @@ class AlwaysOnTop extends EventEmitter {
              */
             getCurrentSize: () => {
                 if (this._alwaysOnTopBrowserWindow) {
-                    const [width, height] = this._alwaysOnTopBrowserWindow.getSize();
-                    return { width, height };
+                    try {
+                        const [width, height] = this._alwaysOnTopBrowserWindow.getSize();
+                        return { width, height };
+                    } catch (ignore) {}
                 }
 
                 return SIZE;
@@ -385,13 +389,15 @@ class AlwaysOnTop extends EventEmitter {
      */
     _closeAlwaysOnTopWindow() {
         if (exists(this._alwaysOnTopBrowserWindow)) {
-            const position =
-                this._alwaysOnTopBrowserWindow.getPosition();
+            try {
+                const position =
+                    this._alwaysOnTopBrowserWindow.getPosition();
 
-            this._position = {
-                x: position[0],
-                y: position[1]
-            };
+                this._position = {
+                    x: position[0],
+                    y: position[1]
+                };
+            } catch (ignore) {}
         }
 
         if (this._alwaysOnTopWindow) {
@@ -420,7 +426,9 @@ class AlwaysOnTop extends EventEmitter {
      */
     _showAlwaysOnTopWindow() {
       if (exists(this._alwaysOnTopBrowserWindow)) {
-        this._alwaysOnTopBrowserWindow.showInactive();
+        try {
+          this._alwaysOnTopBrowserWindow.showInactive();
+        } catch (ignore) {}
       }
     }
 
@@ -431,7 +439,9 @@ class AlwaysOnTop extends EventEmitter {
      */
     _hideAlwaysOnTopWindow() {
       if (exists(this._alwaysOnTopBrowserWindow)) {
-        this._alwaysOnTopBrowserWindow.hide();
+        try {
+          this._alwaysOnTopBrowserWindow.hide();
+        } catch (ignore) {}
       }
     }
 


### PR DESCRIPTION
After AoT is closed, calling win methods (e.g. hide) throw exceptions even the isDestroyed method returns false.