### PR TITLE
Revert "fix(screenshare): Fix screen capture permissions lib not bein…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jitsi-meet-electron-utils",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jitsi-meet-electron-utils",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "Utilities for jitsi-meet-electron project",
   "main": "index.js",
   "scripts": {

--- a/screensharing/main.js
+++ b/screensharing/main.js
@@ -3,7 +3,6 @@ const electron = require('electron');
 
 const { SCREEN_SHARE_EVENTS_CHANNEL, SCREEN_SHARE_EVENTS, TRACKER_SIZE } = require('./constants');
 const { isMac } = require('./utils');
-const macScreenCapturePermissions = require('mac-screen-capture-permissions');
 
 /**
  * Main process component that sets up electron specific screen sharing functionality, like screen sharing
@@ -121,7 +120,7 @@ class ScreenShareMainHook {
             hasPromptedForPermission,
             hasScreenCapturePermission,
             resetPermissions,
-        } = macScreenCapturePermissions;
+        } = require('mac-screen-capture-permissions');
 
         const hasPermission = hasScreenCapturePermission();
         const promptedAlready = hasPromptedForPermission();


### PR DESCRIPTION
…g bundled"

This reverts commit e907e06c0101cddba04c321f126fd6b2b07892fd.

Update version to 2.0.10

This fixes issues with apps using electron packager for bundling deps