### PR TITLE
Use AOT window layering to allow it to render above full screen apps

### DIFF
--- a/alwaysontop/main.js
+++ b/alwaysontop/main.js
@@ -70,6 +70,9 @@ function onAlwaysOnTopWindow(
             }, getPosition(), getSize())
         );
 
+        // Required to allow the window to be rendered on top of full screen apps
+        win.setAlwaysOnTop(true, 'screen-saver');
+
         //the renderer process tells the main process to close the BrowserWindow
         //this is needed when open and close AOT are called in quick succession on renderer process.
         ipcMain.once('jitsi-always-on-top-should-close', () => {


### PR DESCRIPTION
This solves AOT rendering above full-screen applications (on windows Remote Desktop Connection for example) which allow users in a meeting to open a RDP connection and still see the meeting AOT window above it (especially important if the user has a single screen).

See a lengthy in-depth discussion here https://github.com/electron/electron/issues/10078