### PR TITLE
Fix screen-sharing tracker on Electron 12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jitsi-meet-electron-utils",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jitsi-meet-electron-utils",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "Utilities for jitsi-meet-electron project",
   "main": "index.js",
   "scripts": {

--- a/screensharing/main.js
+++ b/screensharing/main.js
@@ -90,7 +90,8 @@ class ScreenShareMainHook {
             frame: false,
             show: false,
             webPreferences: {
-                // TODO: these 2 should be removed.
+                // TODO: these 3 should be removed.
+                contextIsolation: false,
                 enableRemoteModule: true,
                 nodeIntegration: true
             }


### PR DESCRIPTION
Context isolation must be disabled, until we support it properly.