### PR TITLE
feat(deps) update mac-screen-capture-permissions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1966,8 +1966,9 @@
       }
     },
     "mac-screen-capture-permissions": {
-      "version": "github:saghul/mac-screen-capture-permissions#14568eba35b0eebcf2b1b5c40d2c35fec3d88e89",
-      "from": "github:saghul/mac-screen-capture-permissions#14568eba35b0eebcf2b1b5c40d2c35fec3d88e89",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mac-screen-capture-permissions/-/mac-screen-capture-permissions-2.0.0.tgz",
+      "integrity": "sha512-f70KKpx5WhD8mmrAwLeeee31EfSM4p1K7kBBNBVXyfWE7ZQTIbbAF2PxJ0bMsDxyyeX5roBcH+qJYlSTANtCOA==",
       "requires": {
         "electron-util": "^0.13.0",
         "execa": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "Apache-2.0",
   "gypfile": true,
   "dependencies": {
-    "mac-screen-capture-permissions": "github:saghul/mac-screen-capture-permissions#14568eba35b0eebcf2b1b5c40d2c35fec3d88e89",
+    "mac-screen-capture-permissions": "^2.0.0",
     "nan": "^2.14.0",
     "postis": "^2.2.0",
     "prebuild-install": "^5.3.0",


### PR DESCRIPTION
karaggeorge/mac-screen-capture-permissions#8 was merged and released as 2.0.0,
so switch back to released upstream version.