### PR TITLE
fix(remotecontrol): make native module context-aware

### DIFF
--- a/node_addons/sourceId2Coordinates/src/index.cc
+++ b/node_addons/sourceId2Coordinates/src/index.cc
@@ -33,4 +33,4 @@ NAN_MODULE_INIT(Init)
 	);
 }
 
-NODE_MODULE(sourceId2CoordinatesModule, Init)
+NAN_MODULE_WORKER_ENABLED(sourceId2CoordinatesModule, Init)


### PR DESCRIPTION
Fixes deprecation warning as all modules have to be context-aware for
electron 14+

See https://github.com/electron/electron/issues/18397

Signed-off-by: Christoph Settgast <csett86@web.de>