### PR TITLE
deps: switch to electron 13 compatible robotjs fork

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3050,30 +3050,13 @@
       }
     },
     "robotjs": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/robotjs/-/robotjs-0.6.0.tgz",
-      "integrity": "sha512-6pRWI3d+CBZqCXT/rsJfabbZoELua+jTeXilG27F8Jvix/J2BYZ0O7Tly2WCmXyqw5xYdCvOwvCeLRHEtXkt4w==",
+      "version": "github:csett86/robotjs#eef684acb1844959106ef64228c3f32efc535303",
+      "from": "github:csett86/robotjs#v0.6.1",
       "requires": {
-        "nan": "^2.14.0",
-        "node-abi": "^2.13.0",
+        "nan": "^2.14.2",
         "prebuild-install": "^5.3.3"
       },
       "dependencies": {
-        "node-abi": {
-          "version": "2.13.0",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.13.0.tgz",
-          "integrity": "sha512-9HrZGFVTR5SOu3PZAnAY2hLO36aW1wmA+FDsVkr85BTST32TLCA1H/AEcatVRAsWLyXS3bqUDYCAjq5/QGuSTA==",
-          "requires": {
-            "semver": "^5.4.1"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "5.7.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-            }
-          }
-        },
         "prebuild-install": {
           "version": "5.3.6",
           "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "nan": "^2.14.2",
     "postis": "^2.2.0",
     "prebuild-install": "^5.3.0",
-    "robotjs": "0.6.0",
+    "robotjs": "github:csett86/robotjs#v0.6.1",
     "jitsi-meet-logger": "github:jitsi/jitsi-meet-logger#v1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This is closely tracking upstream and only has https://github.com/octalmage/robotjs/pull/679 merged in to be able to compile with node 14 (part of electron 13). The compile errors are in nan, not in robotjs itself, so the PR is only to update nan dependency of robotjs to the current version.