### PR TITLE
fix: Update prebuild to update node-gyp dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "jitsi-meet-electron-utils",
-      "version": "2.0.22",
+      "version": "3.0.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -22,7 +22,7 @@
         "eslint-plugin-jsdoc": "*",
         "mocha": "^8.2.1",
         "node-abi": "^2.30.0",
-        "prebuild": "^10.0.1",
+        "prebuild": "^11.0.0",
         "precommit-hook": "3.0.0"
       }
     },
@@ -3561,9 +3561,9 @@
       "integrity": "sha1-3F4yN2WYXd/cv9r8MUGpVprvdak="
     },
     "node_modules/prebuild": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/prebuild/-/prebuild-10.0.1.tgz",
-      "integrity": "sha512-x0CkKDmHFwX49rTGEYJwB9jBQwJWxRzwUtP5PA9dP8khFGMm3oSFgYortxdlp0PkxB29EhWGp/KQE5g+adehYg==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/prebuild/-/prebuild-11.0.0.tgz",
+      "integrity": "sha512-Vmr240YZZXTXOHFMvGrNaPN/PYFZSxKwiJNSxpwvW215B0mkhwHccVQHtklK4pXeXS80gYGpe5mt72zhKjBPQg==",
       "dev": true,
       "dependencies": {
         "cmake-js": "~5.2.0",
@@ -3576,7 +3576,7 @@
         "minimist": "^1.1.2",
         "mkdirp": "^0.5.1",
         "napi-build-utils": "^1.0.1",
-        "node-abi": "^2.2.0",
+        "node-abi": "^3.0.0",
         "node-gyp": "^6.0.1",
         "node-ninja": "^1.0.1",
         "noop-logger": "^0.1.0",
@@ -3591,7 +3591,7 @@
         "prebuild": "bin.js"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
       }
     },
     "node_modules/prebuild-install": {
@@ -3640,6 +3640,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/prebuild/node_modules/node-abi": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.3.0.tgz",
+      "integrity": "sha512-/+2sCVPXmj07GY/l0ggRr7+trqzX7F9d4QVfSArqIVYmRzc/LkXKr5FlRO6U8uZ/gVVclDDaBxBNITj1z1Z/Zw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/precommit-hook": {
@@ -6687,6 +6714,7 @@
     },
     "jitsi-meet-logger": {
       "version": "git+ssh://git@github.com/jitsi/jitsi-meet-logger.git#4add5bac2e4cea73a05f42b7596ee03c7f7a2567",
+      "integrity": "sha512-1WC//tMrc8lAxfldhEYFxk8EZuHwBcJgy+QDzd9E7ZJCCm5r+aUYshnx69PLwcbf7iLfKPhcuCKz8FOJRpBdXg==",
       "from": "jitsi-meet-logger@github:jitsi/jitsi-meet-logger#v1.0.0"
     },
     "js-tokens": {
@@ -7721,9 +7749,9 @@
       "integrity": "sha1-3F4yN2WYXd/cv9r8MUGpVprvdak="
     },
     "prebuild": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/prebuild/-/prebuild-10.0.1.tgz",
-      "integrity": "sha512-x0CkKDmHFwX49rTGEYJwB9jBQwJWxRzwUtP5PA9dP8khFGMm3oSFgYortxdlp0PkxB29EhWGp/KQE5g+adehYg==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/prebuild/-/prebuild-11.0.0.tgz",
+      "integrity": "sha512-Vmr240YZZXTXOHFMvGrNaPN/PYFZSxKwiJNSxpwvW215B0mkhwHccVQHtklK4pXeXS80gYGpe5mt72zhKjBPQg==",
       "dev": true,
       "requires": {
         "cmake-js": "~5.2.0",
@@ -7736,7 +7764,7 @@
         "minimist": "^1.1.2",
         "mkdirp": "^0.5.1",
         "napi-build-utils": "^1.0.1",
-        "node-abi": "^2.2.0",
+        "node-abi": "^3.0.0",
         "node-gyp": "^6.0.1",
         "node-ninja": "^1.0.1",
         "noop-logger": "^0.1.0",
@@ -7760,6 +7788,24 @@
             "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
+          }
+        },
+        "node-abi": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.3.0.tgz",
+          "integrity": "sha512-/+2sCVPXmj07GY/l0ggRr7+trqzX7F9d4QVfSArqIVYmRzc/LkXKr5FlRO6U8uZ/gVVclDDaBxBNITj1z1Z/Zw==",
+          "dev": true,
+          "requires": {
+            "semver": "^7.3.5"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-jsdoc": "*",
     "mocha": "^8.2.1",
     "node-abi": "^2.30.0",
-    "prebuild": "^10.0.1",
+    "prebuild": "^11.0.0",
     "precommit-hook": "3.0.0"
   }
 }


### PR DESCRIPTION
previous node-gyp is too old to be used with npm8 / node16, fails
(only) on windows.